### PR TITLE
riscv: Use updated bfd to elf reloc map for gas

### DIFF
--- a/bfd/ChangeLog.COREV
+++ b/bfd/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2020-09-11  Simon Cook  <simon.cook@embecosm.com>
+
+	* bfd/elfxx-riscv.c (riscv_reloc_type_lookup): Call
+	to do howto lookup.
+
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* bfd-in2.h: Added CORE-V hardware loop specific relocations.

--- a/bfd/elfxx-riscv.c
+++ b/bfd/elfxx-riscv.c
@@ -952,22 +952,6 @@ static const struct elf_reloc_map riscv_reloc_map[] =
   { BFD_RELOC_RISCV_RELU5, R_RISCV_RELU5 },
 };
 
-/* Given a BFD reloc type, return a howto structure.  */
-
-reloc_howto_type *
-riscv_reloc_type_lookup (bfd *abfd ATTRIBUTE_UNUSED,
-			 bfd_reloc_code_real_type code)
-{
-  unsigned int i;
-
-  for (i = 0; i < ARRAY_SIZE (riscv_reloc_map); i++)
-    if (riscv_reloc_map[i].bfd_val == code)
-      return &howto_table[(int) riscv_reloc_map[i].elf_val];
-
-  bfd_set_error (bfd_error_bad_value);
-  return NULL;
-}
-
 reloc_howto_type *
 riscv_reloc_name_lookup (bfd *abfd ATTRIBUTE_UNUSED, const char *r_name)
 {
@@ -988,12 +972,29 @@ riscv_elf_rtype_to_howto (bfd *abfd, unsigned int r_type)
     {
       if (r_type == howto_table[i].type)
         return &howto_table[i];
-    }	  
+    }
   (*_bfd_error_handler) (_("%pB: unsupported relocation type %#x"),
-		        abfd, r_type);
+		         abfd, r_type);
   bfd_set_error (bfd_error_bad_value);
   return NULL;
 }
+
+/* Given a BFD reloc type, return a howto structure.  */
+
+reloc_howto_type *
+riscv_reloc_type_lookup (bfd *abfd,
+			 bfd_reloc_code_real_type code)
+{
+  unsigned int i;
+
+  for (i = 0; i < ARRAY_SIZE (riscv_reloc_map); i++)
+    if (riscv_reloc_map[i].bfd_val == code)
+      return riscv_elf_rtype_to_howto(abfd, riscv_reloc_map[i].elf_val);
+
+  bfd_set_error (bfd_error_bad_value);
+  return NULL;
+}
+
 
 /* Special_function of RISCV_ADD and RISCV_SUB relocations.  */
 


### PR DESCRIPTION
This updates the BFD relocation to ELF howto function to use the
updated table scanner now that relocs are not contiguous.

bfd/ChangeLog:

	* bfd/elfxx-riscv.c (riscv_reloc_type_lookup): Call
	to do howto lookup.